### PR TITLE
Avoid Gosub constructs so it is in future safe to add inlining

### DIFF
--- a/MOSPEED native compiler.txt
+++ b/MOSPEED native compiler.txt
@@ -56,7 +56,9 @@ Examples are the often used addresses for VIC or SID. Default is true.
 - /constprop=true|false: If true, constant propagation will be used. I.e. constants won't only just detected directly, 
 but also if calculations result in constant values. Default is true.
 
-- /ilangopt=true|false: If true, the generated intermediate code will be optimized. This increases the speed and usually 
+- /pcodeopt=true|false: If true, inlining and other high level optimizations will be performed. Default is false.
+
+- /ilangopt=true|false: If true, the generated intermediate code will be optimized. This increases the speed and usually
 reduces the size. Default is true.
 
 - /nlangopt=true|false: If true, the generated 6502-Assembly code will be optimized. This increases the speed and usually 

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,20 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.0.2</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>8</source>
+					<target>8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 
 </project>

--- a/src/main/java/com/sixtyfour/cbmnative/NativeCompiler.java
+++ b/src/main/java/com/sixtyfour/cbmnative/NativeCompiler.java
@@ -212,6 +212,10 @@ public class NativeCompiler {
 	    ConstantPropagator.propagateConstants(config, machine);
 	    ConstantFolder.foldConstants(config, machine);
 	    DeadStoreEliminator.eliminateDeadStores(config, basic);
+
+	}
+	if(config.isPcodeOptimize()) {
+		pCode.optimize();
 	}
 
 	basic.modifyDelayLoops(config);

--- a/src/main/java/com/sixtyfour/cbmnative/PCode.java
+++ b/src/main/java/com/sixtyfour/cbmnative/PCode.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.sixtyfour.cbmnative.crossoptimizer.PCodeOptimizer;
 import com.sixtyfour.parser.Line;
 
 /**
@@ -47,6 +48,10 @@ public class PCode {
      */
     public List<Integer> getLineNumbers() {
 	return lineNumbers;
+    }
+
+    public boolean optimize(){
+        return PCodeOptimizer.optimize(this);
     }
 
 }

--- a/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/PCodeOptimizer.java
+++ b/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/PCodeOptimizer.java
@@ -1,0 +1,39 @@
+package com.sixtyfour.cbmnative.crossoptimizer;
+
+import com.sixtyfour.cbmnative.PCode;
+import com.sixtyfour.cbmnative.crossoptimizer.common.OrderedPCode;
+import com.sixtyfour.cbmnative.crossoptimizer.passes.InlineOneBlockGosub;
+import com.sixtyfour.elements.commands.Command;
+import com.sixtyfour.parser.Line;
+
+import java.util.List;
+
+public class PCodeOptimizer {
+
+    public static void replaceOneCommandInLine(Line line, Command command, String code) {
+        List<Command> originalRowCommands = line.getCommands();
+        originalRowCommands.clear();
+        originalRowCommands.add(command);
+        line.setLine(code);
+    }
+
+    public static boolean optimize(PCode pCode) {
+        OrderedPCode orderedPCode = new OrderedPCode(pCode);
+        boolean result = false;
+        InlineOneBlockGosub onlyOneMethodCallInliner = new InlineOneBlockGosub();
+        result |= onlyOneMethodCallInliner.optimize(orderedPCode);
+        if (result) {
+            updatePcode(pCode, orderedPCode);
+        }
+        return result;
+    }
+
+    private static void updatePcode(PCode pCode, OrderedPCode orderedPCode) {
+        pCode.getLines().clear();
+        pCode.getLineNumbers().clear();
+        for(Line line: orderedPCode.getLines()){
+            pCode.getLineNumbers().add(line.getNumber());
+            pCode.getLines().put(line.getNumber(), line);
+        }
+    }
+}

--- a/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/common/OrderedPCode.java
+++ b/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/common/OrderedPCode.java
@@ -1,0 +1,43 @@
+package com.sixtyfour.cbmnative.crossoptimizer.common;
+
+import com.sixtyfour.cbmnative.PCode;
+import com.sixtyfour.parser.Line;
+
+import java.util.*;
+
+public class OrderedPCode {
+    List<Line> allLines = new ArrayList<>();
+    Map<Integer, Integer> rowMapping = new HashMap<>();
+    public OrderedPCode(PCode pCode){
+        Collection<Line> lines = pCode.getLines().values();
+        SortedMap<Integer, Line> orderedLines = new TreeMap<>();
+        for(Line line: lines){
+            orderedLines.put(line.getNumber(), line);
+        }
+        int pos = 0;
+        for(Line orderedLine: orderedLines.values()){
+            allLines.add(orderedLine);
+            rowMapping.put(orderedLine.getNumber(), pos);
+            pos++;
+        }
+
+
+    }
+
+    public List<Line> getLines() {
+        return allLines;
+    }
+
+    public Line getLine(int lineNumber) {
+        int targetLine = getLineIndex(lineNumber);
+        return getLineDirect(targetLine);
+    }
+
+    public int getLineIndex(int lineNumber) {
+        return rowMapping.get(lineNumber);
+    }
+
+    public Line getLineDirect(int targetLine) {
+        return allLines.get(targetLine);
+    }
+}

--- a/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/common/PCodeVisitor.java
+++ b/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/common/PCodeVisitor.java
@@ -1,0 +1,23 @@
+package com.sixtyfour.cbmnative.crossoptimizer.common;
+
+import com.sixtyfour.elements.commands.Command;
+import com.sixtyfour.parser.Line;
+
+public class PCodeVisitor {
+    public interface IVisitor{
+        void consume(Line line, Command command);
+    }
+    public void accept(OrderedPCode orderedPCode, String commandPrefix, IVisitor onHit) {
+        String prefixSearch = commandPrefix.toLowerCase();
+        for(Line line: orderedPCode.getLines())
+        {
+            for(Command command: line.getCommands())
+            {
+                String commandName =command.getName().toLowerCase();
+                if(commandName.equals(prefixSearch)){
+                    onHit.consume(line, command);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/passes/InlineOneBlockGosub.java
+++ b/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/passes/InlineOneBlockGosub.java
@@ -1,0 +1,116 @@
+package com.sixtyfour.cbmnative.crossoptimizer.passes;
+
+import com.sixtyfour.cbmnative.crossoptimizer.PCodeOptimizer;
+import com.sixtyfour.cbmnative.crossoptimizer.common.OrderedPCode;
+import com.sixtyfour.cbmnative.crossoptimizer.common.PCodeVisitor;
+import com.sixtyfour.elements.commands.Command;
+import com.sixtyfour.elements.commands.Gosub;
+import com.sixtyfour.elements.commands.Goto;
+import com.sixtyfour.elements.commands.Return;
+import com.sixtyfour.parser.Line;
+
+import java.util.*;
+
+
+/**
+ * This code transform assumes makes the following transformation:
+ *
+ * L: gosub N
+ * L+1: ...
+ * (...)
+ * N: ...
+ * return
+ *
+ * if the gosub to N is unique, the code is transformed to:
+ *
+ * L: goto N
+ * L+1: ...
+ * (...)
+ * N: (...)
+ * goto L+1
+ *
+ *
+ */
+public class InlineOneBlockGosub {
+
+    private void addCount(Map<Integer, Integer> countedGoSubs, int targetLine) {
+        Integer getTargetCount = countedGoSubs.get(targetLine);
+        if (getTargetCount == null) {
+            countedGoSubs.put(targetLine, 1);
+        } else {
+            countedGoSubs.put(targetLine, 1 + getTargetCount);
+        }
+    }
+
+    public boolean optimize(OrderedPCode orderedPCode) {
+        List<Integer> linesWithSingleGosub = getInlinableGosubs(orderedPCode);
+
+        for (int lineWithGosub : linesWithSingleGosub) {
+            Line line = orderedPCode.getLine(lineWithGosub);
+            Gosub gosub = line.getFirstCommand();
+            Goto replaceGoto = new Goto();
+            replaceGoto.setTargetLineNumber(gosub.getTargetLineNumber());
+            PCodeOptimizer.replaceOneCommandInLine(line, replaceGoto, "goto "+gosub.getTargetLineNumber());
+            int targetGosubStart = orderedPCode.getLineIndex(gosub.getTargetLineNumber());
+            for (int targetReturn = targetGosubStart; ; targetReturn++) {
+                Line candidateReturnLine = orderedPCode.getLineDirect(targetReturn);
+                Return retCommand = candidateReturnLine.getFirstCommand(Return.class);
+                if (retCommand == null)
+                    continue;
+                InlineCall(orderedPCode, lineWithGosub, gosub, candidateReturnLine);
+
+
+                break;
+            }
+        }
+        final int countReplacements = linesWithSingleGosub.size();
+        if (countReplacements > 0) {
+            System.out.println("Inline gosub count: " + countReplacements);
+        }
+        return countReplacements != 0;
+    }
+
+    private void InlineCall(OrderedPCode orderedPCode, int lineWithGosub, Gosub gosub, Line returnLine) {
+        int gosubIndex = orderedPCode.getLineIndex(lineWithGosub);
+        Goto gotoNext = new Goto();
+        int nextLineIndex = orderedPCode.getLineDirect(gosubIndex + 1).getNumber();
+        gotoNext.setTargetLineNumber(nextLineIndex);
+        PCodeOptimizer.replaceOneCommandInLine(returnLine, gotoNext, "goto "+nextLineIndex);
+
+        System.out.println(lineWithGosub+": GOSUB " + gosub.getTargetLineNumber() + "' is converted to 'Goto' and method is inlined from range: (" + gosub.getTargetLineNumber() + ".."
+                + returnLine.getNumber() + ")");
+    }
+
+    private List<Integer> getInlinableGosubs(OrderedPCode orderedPCode) {
+        Map<Integer, Integer> countedGoSubs = new HashMap<>();
+        Set<Integer> excludedCandidates = new HashSet<>();
+        List<Integer> linesWithSingleGoSub = new ArrayList<>();
+        PCodeVisitor pCodeVisitor = new PCodeVisitor();
+        PCodeVisitor.IVisitor visitor = (Line l, Command command) -> {
+            Gosub gosub = (Gosub) command;
+            int target = gosub.getTargetLineNumber();
+
+            addCount(countedGoSubs, target);
+            if (l.getCommands().size() != 1) {
+                excludedCandidates.add(target);
+            } else {
+                linesWithSingleGoSub.add(l.getNumber());
+            }
+        };
+        pCodeVisitor.accept(orderedPCode, "gosub", visitor);
+        List<Integer> singleGosubs = new ArrayList<>();
+        for (int lineIndex : linesWithSingleGoSub) {
+            Line line = orderedPCode.getLine(lineIndex);
+            Command c = line.getCommands().get(0);
+            Gosub gosub = line.getFirstCommand();
+            int gosubTarget = gosub.getTargetLineNumber();
+            int gosubCount = countedGoSubs.get(gosubTarget);
+            if (gosubCount != 1)
+                continue;
+            if (excludedCandidates.contains(gosubTarget))
+                continue;
+            singleGosubs.add(lineIndex);
+        }
+        return singleGosubs;
+    }
+}

--- a/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/passes/InlineOneBlockGosub.java
+++ b/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/passes/InlineOneBlockGosub.java
@@ -1,5 +1,6 @@
 package com.sixtyfour.cbmnative.crossoptimizer.passes;
 
+import com.sixtyfour.Logger;
 import com.sixtyfour.cbmnative.crossoptimizer.PCodeOptimizer;
 import com.sixtyfour.cbmnative.crossoptimizer.common.OrderedPCode;
 import com.sixtyfour.cbmnative.crossoptimizer.common.PCodeVisitor;
@@ -77,7 +78,7 @@ public class InlineOneBlockGosub {
         gotoNext.setTargetLineNumber(nextLineIndex);
         PCodeOptimizer.replaceOneCommandInLine(returnLine, gotoNext, "goto "+nextLineIndex);
 
-        System.out.println(lineWithGosub+": GOSUB " + gosub.getTargetLineNumber() + "' is converted to 'Goto' and method is inlined from range: (" + gosub.getTargetLineNumber() + ".."
+        Logger.log(lineWithGosub+": GOSUB " + gosub.getTargetLineNumber() + "' is converted to 'Goto' and method is inlined from range: (" + gosub.getTargetLineNumber() + ".."
                 + returnLine.getNumber() + ")");
     }
 

--- a/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/passes/InlineOneBlockGosub.java
+++ b/src/main/java/com/sixtyfour/cbmnative/crossoptimizer/passes/InlineOneBlockGosub.java
@@ -14,7 +14,7 @@ import java.util.*;
 
 
 /**
- * This code transform assumes makes the following transformation:
+ * This code transform makes the following transformation if gosub to N is unique:
  *
  * L: gosub N
  * L+1: ...
@@ -22,7 +22,7 @@ import java.util.*;
  * N: ...
  * return
  *
- * if the gosub to N is unique, the code is transformed to:
+ * Code is transformed to:
  *
  * L: goto N
  * L+1: ...

--- a/src/main/java/com/sixtyfour/cbmnative/shell/MoSpeedCL.java
+++ b/src/main/java/com/sixtyfour/cbmnative/shell/MoSpeedCL.java
@@ -77,6 +77,7 @@ public class MoSpeedCL {
 
 		cfg.setConstantFolding(getOption("constfolding", cmds));
 		cfg.setConstantPropagation(getOption("constprop", cmds));
+		cfg.setPcodeOptimizations(getOption("pcodeopt", cmds));
 		cfg.setDeadStoreElimination(getOption("deadstoreopt", cmds));
 		cfg.setDeadStoreEliminationOfStrings(getOption("deadstoreoptstr", cmds));
 		cfg.setIntermediateLanguageOptimizations(getOption("ilangopt", cmds));

--- a/src/main/java/com/sixtyfour/config/CompilerConfig.java
+++ b/src/main/java/com/sixtyfour/config/CompilerConfig.java
@@ -13,6 +13,7 @@ public class CompilerConfig {
 
 	private boolean constantPropagation = true;
 	private boolean constantFolding = true;
+	private boolean pcodeOptimize = true;
 	private boolean intermediateLanguageOptimizations = true;
 	private boolean nativeLanguageOptimizations = true;
 	private boolean optimizedLinker = true;
@@ -46,6 +47,13 @@ public class CompilerConfig {
 
 	public void setConstantFolding(boolean constantFolding) {
 		this.constantFolding = constantFolding;
+	}
+
+	public void setPcodeOptimizations(boolean pcodeOptimize) {
+		this.pcodeOptimize = pcodeOptimize;
+	}
+	public boolean isPcodeOptimize(){
+		return pcodeOptimize;
 	}
 
 	public boolean isIntermediateLanguageOptimizations() {

--- a/src/main/java/com/sixtyfour/config/CompilerConfig.java
+++ b/src/main/java/com/sixtyfour/config/CompilerConfig.java
@@ -13,7 +13,7 @@ public class CompilerConfig {
 
 	private boolean constantPropagation = true;
 	private boolean constantFolding = true;
-	private boolean pcodeOptimize = true;
+	private boolean pcodeOptimize = false;
 	private boolean intermediateLanguageOptimizations = true;
 	private boolean nativeLanguageOptimizations = true;
 	private boolean optimizedLinker = true;

--- a/src/main/java/com/sixtyfour/elements/commands/Gosub.java
+++ b/src/main/java/com/sixtyfour/elements/commands/Gosub.java
@@ -20,6 +20,10 @@ public class Gosub extends AbstractCommand {
 	private BasicProgramCounter pc = new BasicProgramCounter(0, 0); // Recycle
 																	// instance
 
+	public int getTargetLineNumber() {
+		return targetLineNumber;
+	}
+
 	private int targetLineNumber = 0;
 
 	/**

--- a/src/main/java/com/sixtyfour/elements/commands/Goto.java
+++ b/src/main/java/com/sixtyfour/elements/commands/Goto.java
@@ -20,6 +20,14 @@ public class Goto extends AbstractCommand {
 	private BasicProgramCounter pc = new BasicProgramCounter(0, 0); // Recycle
 																	// instance
 
+	public int getTargetLineNumber() {
+		return targetLineNumber;
+	}
+
+	public void setTargetLineNumber(int targetLineNumber) {
+		this.targetLineNumber = targetLineNumber;
+	}
+
 	private int targetLineNumber = 0;
 
 	/**

--- a/src/main/java/com/sixtyfour/parser/Line.java
+++ b/src/main/java/com/sixtyfour/parser/Line.java
@@ -112,6 +112,23 @@ public class Line {
 	}
 
 	/**
+	 * Get first command
+	 */
+	public <T extends Command> T getFirstCommand(Class<T> clazz) {
+		final Command firstCommand = commands.get(0);
+		if(firstCommand.getClass().isAssignableFrom(clazz))
+		return (T) firstCommand;
+		return null;
+	}
+	/**
+	 * Get first command
+	 */
+	public <T extends Command> T getFirstCommand() {
+		final Command firstCommand = commands.get(0);
+		return (T) firstCommand;
+	}
+
+	/**
 	 * Returns the count/position of this line in the BASIC program.
 	 * 
 	 * @return the count
@@ -140,4 +157,7 @@ public class Line {
 		return number + " " + line;
 	}
 
+	public void setLine(String line) {
+		this.line = line;
+	}
 }


### PR DESCRIPTION
This PR allows to remove in future some cases of proper inlining (by inline I mean to remove a `gosub` and back code if there is only one way to run the code)
```
 L: gosub N
 L+1: ...
 (...)
 N: ...
 return
 
if the gosub to N is unique, the code is transformed to:

 L: goto N
 L+1: ...
 (...)
 N: (...)
 goto L+1
```
If this PR is built, more work will be done to cleanup the PCode class so it can be easier to navigate and replace stuff in it.