### PR TITLE
shorten INITNARRAY subroutine

### DIFF
--- a/src/main/resources/subroutines.asm
+++ b/src/main/resources/subroutines.asm
@@ -41,22 +41,19 @@ INITNARRAY
 			STA TMP_ZP
 			STY TMP_ZP+1
 			LDY #0
-NINITLOOP	LDA #0
-			STA (TMP_ZP),Y
-			INC TMP_ZP
-			BNE NLOOPNOV
-			INC TMP_ZP+1
-NLOOPNOV	SEC
-			LDA TMP2_ZP
-			SBC #1
-			STA TMP2_ZP
-			BCS NLOOPNOV2
-			DEC TMP2_ZP+1
-NLOOPNOV2	LDA TMP2_ZP
-			BNE NINITLOOP
-			LDA TMP2_ZP+1
-			BNE NINITLOOP
-			RTS
+            		LDA #0
+NINITLOOP	STA (TMP_ZP),Y
+            		INC TMP_ZP
+            		BNE NLOOPNOV
+            		INC TMP_ZP+1
+NLOOPNOV	LDX TMP2_ZP       
+            		BNE NLOOPNOV2
+            		DEC TMP2_ZP+1       
+NLOOPNOV2	DEC TMP2_ZP
+            		BNE NINITLOOP
+            		LDX TMP2_ZP+1
+            		BNE NINITLOOP  
+            		RTS
 ;###################################
 INITSTRARRAY 
 			STA TMP_ZP


### PR DESCRIPTION
In the INITNARRAY subroutine, decrementing `TMP2_ZP` by one can be done more efficiently with `DEC` instead of `SBC #1` (recipe taken from [here](http://www.obelisk.me.uk/6502/algorithms.html) -- section "Incrementing & Decrementing").

This in turn shortens also the "is-zero" check after `NLOOPNOV2` (no `LDA` before `BNE`).

I also used the `X` register within the loop in order to avoid setting `A` to 0 at each iteration.

I haven't tested it (can't build)